### PR TITLE
allow configurable pivoting year (2015 or 2023) for network generation

### DIFF
--- a/scripts/build_network_mtc.py
+++ b/scripts/build_network_mtc.py
@@ -43,11 +43,22 @@ else:
     raise Wrangler.NetworkException(error_message)
 
 # MANDATORY. The network you are buliding on top of.
-# This should be a clone of https://github.com/BayAreaMetro/TM1_2015_Base_Network
-PIVOT_DIR = os.environ['TM1_2015_Base_Network']
-
-# OPTIONAL. If PIVOT_DIR is specified, MANDATORY.  Specifies year for PIVOT_DIR.
+# Requires setting two environment variables - "TM1_2015_Base_Network" and "TM1_2023_Base_Network".
+BASE_NETWORK_ENV_VARS = {
+    2015: 'TM1_2015_Base_Network',
+    2023: 'TM1_2023_Base_Network',
+}
+def get_base_network_dir(pivot_year):
+    pivot_year = int(pivot_year)
+    env_var = BASE_NETWORK_ENV_VARS.get(pivot_year)
+    if env_var is None:
+        raise Wrangler.NetworkException(f"No base network environment variable configured for PIVOT_YEAR={pivot_year}")
+    if env_var not in os.environ:
+        raise Wrangler.NetworkException(f"Set {env_var} environment variable for PIVOT_YEAR={pivot_year}")
+    return os.environ[env_var]
+# default behavior uses the 2015 base network unless a different base year is requested
 PIVOT_YEAR = 2015
+PIVOT_DIR = get_base_network_dir(PIVOT_YEAR)
 
 # MANDATORY. Set this to the directory in which to write your outputs. 
 # "hwy" and "trn" subdirectories will be created here.
@@ -498,7 +509,9 @@ if __name__ == '__main__':
         import geopandas
     
     if args.project_name == 'TIP2025':
-        PIVOT_DIR        = r"M:\Application\\Model One\\Networks\\TM1_2015_Base_Network-TIP_2023"
+        PIVOT_YEAR       = 2015
+        PIVOT_DIR        = get_base_network_dir(PIVOT_YEAR)
+        TRN_NET_NAME     = "transitLines"
 
     TRANSIT_CAPACITY_DIR = os.path.join(PIVOT_DIR, "trn")
 

--- a/scripts/build_network_mtc_blueprint.py
+++ b/scripts/build_network_mtc_blueprint.py
@@ -47,9 +47,10 @@ if __name__ == '__main__':
 
     NOW              = time.strftime("%Y%b%d.%H%M%S")
     BUILD_MODE       = None # regular
-    PIVOT_DIR        = build_network_mtc.PIVOT_DIR
     NETWORK_PROJECTS = build_network_mtc.NETWORK_PROJECTS
-    TRANSIT_CAPACITY_DIR = os.path.join(PIVOT_DIR, "trn")
+    PIVOT_YEAR = build_network_mtc.PIVOT_YEAR
+    PIVOT_DIR = None # to be defined later based on PIVOT_YEAR and environment variables
+    TRANSIT_CAPACITY_DIR = None # to be defined later based on PIVOT_YEAR and environment variables
     TRN_NET_NAME     = "Transit_Lines"
     HWY_NET_NAME     = "freeflow.net"
 
@@ -76,9 +77,19 @@ if __name__ == '__main__':
     if not os.path.exists(SCRATCH_SUBDIR): os.mkdir(SCRATCH_SUBDIR)
     os.chdir(SCRATCH_SUBDIR)
 
+    exec(open(NETWORK_CONFIG).read())
+
+    # PIVOT_YEAR overwritted by net_spec
+    PIVOT_DIR = build_network_mtc.get_base_network_dir(PIVOT_YEAR)
+    if not os.path.exists(PIVOT_DIR):
+        Wrangler.WranglerLogger.fatal(f"Configured PIVOT_YEAR={PIVOT_YEAR} requires an existing base network at {PIVOT_DIR}")
+        sys.exit(-1)
+    if PIVOT_YEAR == 2023:
+        TRN_NET_NAME = "transitLines"
+    TRANSIT_CAPACITY_DIR = os.path.join(PIVOT_DIR, "trn")
     os.environ["CHAMP_node_names"] = os.path.join(PIVOT_DIR,"Node Description.xls")
 
-    exec(open(NETWORK_CONFIG).read())
+    Wrangler.WranglerLogger.info(f"Using PIVOT_YEAR={PIVOT_YEAR}, PIVOT_DIR={PIVOT_DIR}")
 
     # TODO: This should be in the NGF netspec rather than here
     # Use the NGF_NoProject git tag when building a Next Gen Freeways No Project variant
@@ -107,6 +118,11 @@ if __name__ == '__main__':
     #       for restart=2020 hwy, start applying 2020 hwy projects, using 2015 hwy and 2015 transit
     #
     if args.restart_year or args.restart_mode:
+        # restart_year should be larger than base year
+        if int(args.restart_year) <= PIVOT_YEAR:
+            Wrangler.WranglerLogger.fatal("args.restart_year must be larger than PIVOT_YEAR; args={}".format(args))
+            sys.exit(-1)
+
         # both are required
         if not args.restart_year or not args.restart_mode:
             Wrangler.WranglerLogger.fatal("Both args.restart_year and args.restart_mode are required if one is supplied; args={}".format(args))
@@ -169,7 +185,28 @@ if __name__ == '__main__':
     networks_without_earthquake = {}
 
     # Network Loop #2: Now that everything has been checked, build the networks.
+    # copy 2023 pivot network if starting from 2023 PIVOT_YEAR
+    if PIVOT_YEAR == 2023:
+        Wrangler.WranglerLogger.info("Skipping building 2023 PIVOT_YEAR, copy pivot network instead")
+        # create the subdir
+        # copy the hwy and trn files from the pivot directory
+        for netmode in build_network_mtc.NET_MODES:
+            pivot_dir = os.path.join(PIVOT_DIR, netmode)
+            out_dir = os.path.join("..", "BlueprintNetworks", "net_2023_{}".format(NET_VARIANT), netmode)
+            os.makedirs(out_dir, exist_ok=True)
+            for item in os.listdir(pivot_dir):
+                s = os.path.join(pivot_dir, item)
+                d = os.path.join(out_dir, item)
+                if os.path.isdir(s):
+                    shutil.copytree(s, d, dirs_exist_ok=True)
+                else:
+                    shutil.copy2(s, d)
+    # For PIVOT_YEAR=2023, skip 2023 because it was copied from pivot.
+    # For PIVOT_YEAR=2015, build starting from 2015.
     for YEAR in NETWORK_PROJECTS.keys():
+        if YEAR < PIVOT_YEAR or (PIVOT_YEAR == 2023 and YEAR == PIVOT_YEAR):
+            Wrangler.WranglerLogger.info("PIVOT_YEAR {} specified; skipping {}".format(PIVOT_YEAR, YEAR))
+            continue
         if args.restart_year and YEAR < int(args.restart_year):
             Wrangler.WranglerLogger.info("Restart year {} specified; skipping {}".format(args.restart_year, YEAR))
             continue

--- a/scripts/net_spec_blueprint.py
+++ b/scripts/net_spec_blueprint.py
@@ -3,6 +3,12 @@ import os, pathlib
 # e.g. "RTP2021", "TIP2021", etc
 PROJECT  = "Blueprint"
 
+# OPTIONAL. Base network year for blueprint build script. Supported values are
+# tied to environment variables in build_network_mtc.py (currently 2015, 2023).
+# if 2015, start from 2015 base network and apply all projects from 2015 and onward;
+# if 2023, start from 2023 base network and apply all projects from 2025 and onward.
+PIVOT_YEAR = 2023
+
 # MANDATORY. Set this to be the git tag for checking out network projects.
 TAG = "PBA50plus_Blueprint"  # This is the default tag since this is the netspec for the Blueprint 
 
@@ -532,6 +538,10 @@ ROADWAY_PRICING_STRATEGIES = [
 T10_SAFETY_STRATEGY = 'BP_Vision_Zero'
 
 for YEAR in COMMITTED_PROJECTS.keys():
+    if PIVOT_YEAR == 2023 and YEAR <= PIVOT_YEAR:
+        Wrangler.WranglerLogger.info(f"PIVOT_YEAR={PIVOT_YEAR}; skipping {YEAR} projects in NETWORK_PROJECTS")
+        continue
+
     if NET_VARIANT == "Baseline":
         # baseline: just committed
         NETWORK_PROJECTS[YEAR] = {


### PR DESCRIPTION
### Summary
This PR adds support for building future networks from either a 2015 or 2023 base network.

Previously, network builds started from the 2015 base only.
Now, base-year selection is supported via netspec ([PIVOT_YEAR](https://github.com/BayAreaMetro/NetworkWrangler/blob/start_from_2023/scripts/net_spec_blueprint.py#L6-L10)), with year-specific base-network resolution and build behavior.

### Why
This enables faster and cleaner scenario generation when a validated 2023 base network already exists using the same net_spec, while preserving backward-compatible 2015-first workflows.

### What Changed

- Added year-to-environment-variable base-network mapping in [build_network_mtc.py](https://github.com/BayAreaMetro/NetworkWrangler/blob/start_from_2023/scripts/build_network_mtc.py#L45-L50), determining base networks directory env variable based on `PIVOT_YEAR`.

- Added to `net_spec_blueprint.py` a pivot-year configuration [PIVOT_YEAR](https://github.com/BayAreaMetro/NetworkWrangler/blob/start_from_2023/scripts/net_spec_blueprint.py#L6-L10).
 

- Updated project list assembly to [skip years <=2023 when PIVOT_YEAR == 2023](https://github.com/BayAreaMetro/NetworkWrangler/blob/start_from_2023/scripts/net_spec_blueprint.py#L541-L543).
- Updated `build_network_mtc_blueprint.py` to honor PIVOT_YEAR config:
  - Reads [PIVOT_YEAR](https://github.com/BayAreaMetro/NetworkWrangler/blob/a364db6debaab3c141af44b674745a6ecee91526/scripts/build_network_mtc_blueprint.py#L51) which is then updated from [netspec execution](https://github.com/BayAreaMetro/NetworkWrangler/blob/a364db6debaab3c141af44b674745a6ecee91526/scripts/build_network_mtc_blueprint.py#L80); then [sets `PIVOT_DIR and related variables](https://github.com/BayAreaMetro/NetworkWrangler/blob/start_from_2023/scripts/build_network_mtc_blueprint.py#L83-L90).
  - Build loop logic: if 
`PIVOT_YEAR == 2023`, [copies](https://github.com/BayAreaMetro/NetworkWrangler/blob/start_from_2023/scripts/build_network_mtc_blueprint.py#L189-L203) 2023 network from pivot dir and [skips rebuilding 2023](https://github.com/BayAreaMetro/NetworkWrangler/blob/a364db6debaab3c141af44b674745a6ecee91526/scripts/build_network_mtc_blueprint.py#L207-L208); if `PIVOT_YEAR == 2015`, builds networks starting at 2015 (no skip of 2015).

### Behavior Matrix
- PIVOT_YEAR = 2015: 
  - Uses TM1_2015_Base_Network
  - Builds years starting from 2015
- PIVOT_YEAR = 2023:
  - Uses TM1_2023_Base_Network
  - Copies 2023 outputs from pivot dir
  - Builds years after 2023

### Required Environment Variables
- TM1_2015_Base_Network (required for 2015 mode)
- TM1_2023_Base_Network (required for 2023 mode)

### Example Usage

- Set [PIVOT_YEAR](https://github.com/BayAreaMetro/NetworkWrangler/blob/a364db6debaab3c141af44b674745a6ecee91526/scripts/net_spec_blueprint.py#L10) in `net_spec_blueprint.py` to 2013 or 2023
- Run as usual: 
`python build_network_mtc_blueprint.py net_spec_blueprint.py Blueprint`


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214044035880135